### PR TITLE
Initial list of constants copied from StatsFuns

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        include:
+          - version: '1'
+            os: ubuntu-latest
+            arch: x64
+            coverage: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.coverage || false }}
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.coverage
+      - uses: codecov/codecov-action@v1
+        if: matrix.coverage
+        with:
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        if: matrix.coverage
+        with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            path-to-lcov: ./lcov.info

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,27 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,17 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+
+  jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,7 +6,7 @@ on:
       - created
   workflow_dispatch:
 
-  jobs:
+jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -5,3 +5,9 @@ version = "0.1.0"
 
 [compat]
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+name = "IrrationalConstants"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+authors = ["JuliaMath"]
+version = "0.1.0"
+
+[compat]
+julia = "1"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # IrrationalConstants.jl
-defines additional mathematical constants
+
+This package defines the following irrational constants:
+
+```julia
+twoπ       # 2π
+fourπ      # 4π
+halfπ      # π / 2
+quartπ     # π / 4
+invπ       # 1 / π
+twoinvπ    # 2 / π
+fourinvπ   # 4 / π
+inv2π      # 1 / (2π)
+inv4π      # 1 / (4π)
+sqrt2      # √2
+sqrt3      # √3
+sqrtπ      # √π
+sqrt2π     # √2π
+sqrt4π     # √4π
+sqrthalfπ  # √(π / 2)
+invsqrt2   # 1 / √2
+invsqrt2π  # 1 / √2π
+loghalf    # log(1 / 2)
+logtwo     # log(2)
+logπ       # log(π)
+log2π      # log(2π)
+log4π      # log(4π)
+```
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # IrrationalConstants.jl
 
+[![Build Status](https://github.com/JuliaMath/IrrationalConstants.jl/workflows/CI/badge.svg?branch=main)](https://github.com/JuliaMath/IrrationalConstants.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaMath/IrrationalConstants.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaMath/IrrationalConstants.jl)
+[![Coverage](https://coveralls.io/repos/github/JuliaMath/IrrationalConstants.jl/badge.svg?branch=main)](https://coveralls.io/github/JuliaMath/IrrationalConstants.jl?branch=main)
+
 This package defines the following irrational constants:
 
 ```julia

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -1,0 +1,31 @@
+module IrrationalConstants
+
+using Base: @irrational
+
+export
+    twoπ,       # 2π
+    fourπ,      # 4π
+    halfπ,      # π / 2
+    quartπ,     # π / 4
+    invπ,       # 1 / π
+    twoinvπ,    # 2 / π
+    fourinvπ,   # 4 / π
+    inv2π,      # 1 / (2π)
+    inv4π,      # 1 / (4π)
+    sqrt2,      # √2
+    sqrt3,      # √3
+    sqrtπ,      # √π
+    sqrt2π,     # √2π
+    sqrt4π,     # √4π
+    sqrthalfπ,  # √(π / 2)
+    invsqrt2,   # 1 / √2
+    invsqrt2π,  # 1 / √2π
+    loghalf,    # log(1 / 2)
+    logtwo,     # log(2)
+    logπ,       # log(π)
+    log2π,      # log(2π)
+    log4π       # log(4π)
+
+include("stats.jl")
+
+end # module

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,0 +1,26 @@
+# mathematical constants related to statistics
+
+@irrational twoπ   6.2831853071795864769 big(π) * 2.0
+@irrational fourπ  12.566370614359172954 big(π) * 4.0
+@irrational halfπ  1.5707963267948966192 big(π) * 0.5
+@irrational quartπ 0.7853981633974483096 big(π) * 0.25
+
+@irrational invπ     0.31830988618379067154 inv(big(π))
+@irrational twoinvπ  0.63661977236758134308 big(invπ) * 2.0
+@irrational fourinvπ 1.27323954473516268615 big(invπ) * 4.0
+@irrational inv2π    0.159154943091895335769 big(invπ) * 0.5
+@irrational inv4π    0.079577471545947667884 big(invπ) * 0.25
+
+@irrational sqrt2     1.4142135623730950488 sqrt(big(2.0))
+@irrational sqrt3     1.7320508075688772935 sqrt(big(3.0))
+@irrational sqrtπ     1.7724538509055160273 sqrt(big(π))
+@irrational sqrt2π    2.5066282746310005024 sqrt(big(π) * 2.0)
+@irrational sqrt4π    3.5449077018110320546 sqrt(big(π) * 4.0)
+@irrational sqrthalfπ 1.2533141373155002512 sqrt(big(0.5)*π)
+
+@irrational logtwo 0.6931471805599453094 log(big(2.))
+@irrational logπ   1.1447298858494001741 log(big(π))
+@irrational log2π  1.8378770664093454836 log(big(2.)*π)
+@irrational log4π  2.5310242469692907930 log(big(4.)*π)
+
+@irrational loghalf -0.6931471805599453094 log(big(0.5))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -18,6 +18,9 @@
 @irrational sqrt4π    3.5449077018110320546 sqrt(big(π) * 4.0)
 @irrational sqrthalfπ 1.2533141373155002512 sqrt(big(0.5)*π)
 
+@irrational invsqrt2  0.7071067811865475244 inv(big(sqrt2))
+@irrational invsqrt2π 0.3989422804014326779 inv(big(sqrt2π))
+
 @irrational loghalf -0.6931471805599453094 log(big(0.5))
 @irrational logtwo 0.6931471805599453094 log(big(2.))
 @irrational logπ   1.1447298858494001741 log(big(π))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -18,9 +18,8 @@
 @irrational sqrt4π    3.5449077018110320546 sqrt(big(π) * 4.0)
 @irrational sqrthalfπ 1.2533141373155002512 sqrt(big(0.5)*π)
 
+@irrational loghalf -0.6931471805599453094 log(big(0.5))
 @irrational logtwo 0.6931471805599453094 log(big(2.))
 @irrational logπ   1.1447298858494001741 log(big(π))
 @irrational log2π  1.8378770664093454836 log(big(2.)*π)
 @irrational log4π  2.5310242469692907930 log(big(4.)*π)
-
-@irrational loghalf -0.6931471805599453094 log(big(0.5))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,28 +1,28 @@
 # mathematical constants related to statistics
 
-@irrational twoπ   6.2831853071795864769 big(π) * 2.0
-@irrational fourπ  12.566370614359172954 big(π) * 4.0
-@irrational halfπ  1.5707963267948966192 big(π) * 0.5
-@irrational quartπ 0.7853981633974483096 big(π) * 0.25
+@irrational twoπ   6.2831853071795864769 2 * big(π)
+@irrational fourπ  12.566370614359172954 4 * big(π)
+@irrational halfπ  1.5707963267948966192 big(π) / 2
+@irrational quartπ 0.7853981633974483096 big(π) / 4
 
 @irrational invπ     0.31830988618379067154 inv(big(π))
-@irrational twoinvπ  0.63661977236758134308 big(invπ) * 2.0
-@irrational fourinvπ 1.27323954473516268615 big(invπ) * 4.0
-@irrational inv2π    0.159154943091895335769 big(invπ) * 0.5
-@irrational inv4π    0.079577471545947667884 big(invπ) * 0.25
+@irrational twoinvπ  0.63661977236758134308 2 / big(π)
+@irrational fourinvπ 1.27323954473516268615 4 / big(π)
+@irrational inv2π    0.159154943091895335769 inv(2 * big(π))
+@irrational inv4π    0.079577471545947667884 inv(4 * big(π))
 
-@irrational sqrt2     1.4142135623730950488 sqrt(big(2.0))
-@irrational sqrt3     1.7320508075688772935 sqrt(big(3.0))
+@irrational sqrt2     1.4142135623730950488 sqrt(big(2))
+@irrational sqrt3     1.7320508075688772935 sqrt(big(3))
 @irrational sqrtπ     1.7724538509055160273 sqrt(big(π))
-@irrational sqrt2π    2.5066282746310005024 sqrt(big(π) * 2.0)
-@irrational sqrt4π    3.5449077018110320546 sqrt(big(π) * 4.0)
-@irrational sqrthalfπ 1.2533141373155002512 sqrt(big(0.5)*π)
+@irrational sqrt2π    2.5066282746310005024 sqrt(2 * big(π))
+@irrational sqrt4π    3.5449077018110320546 sqrt(4 * big(π))
+@irrational sqrthalfπ 1.2533141373155002512 sqrt(big(π) / 2)
 
-@irrational invsqrt2  0.7071067811865475244 inv(big(sqrt2))
-@irrational invsqrt2π 0.3989422804014326779 inv(big(sqrt2π))
+@irrational invsqrt2  0.7071067811865475244 inv(sqrt(big(2)))
+@irrational invsqrt2π 0.3989422804014326779 inv(sqrt(2 * big(π)))
 
-@irrational loghalf -0.6931471805599453094 log(big(0.5))
-@irrational logtwo 0.6931471805599453094 log(big(2.))
+@irrational loghalf -0.6931471805599453094 log(inv(big(2)))
+@irrational logtwo 0.6931471805599453094 log(big(2))
 @irrational logπ   1.1447298858494001741 log(big(π))
-@irrational log2π  1.8378770664093454836 log(big(2.)*π)
-@irrational log4π  2.5310242469692907930 log(big(4.)*π)
+@irrational log2π  1.8378770664093454836 log(2 * big(π))
+@irrational log4π  2.5310242469692907930 log(4 * big(π))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,6 @@
+using IrrationalConstants
+using Test
+
+@testset "IrrationalConstants.jl" begin
+    # Write your tests here.
+end


### PR DESCRIPTION
I created an initial version of the package by extracting the constants from StatsFuns 0.9.7 (including those that were moved to LogExpFunctions in 0.9.8), as suggested in https://github.com/JuliaMath/IrrationalConstants.jl/issues/1#issuecomment-829508512:

```julia
git checkout v0.9.7
git-filter-repo --path src/constants.jl --path-rename 'src/constants.jl':'src/stats.jl'
```