### PR TITLE
Specialize inv

### DIFF
--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -27,5 +27,6 @@ export
     log4π       # log(4π)
 
 include("stats.jl")
+include("math.jl")
 
 end # module

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,0 +1,23 @@
+if VERSION > v"1.6.0"
+    _one(x) = one(x)
+else
+    _one(x) = true
+end
+
+for (a,b) in [
+    (:twoπ, :inv2π),
+    (:fourπ, :inv4π),
+    (:halfπ, :twoinvπ),
+    (:quartπ, :fourinvπ),
+    (:sqrt2π, :invsqrt2π),
+    (:sqrt2, :invsqrt2),
+    ]
+    Ta = Irrational{a}
+    Tb = Irrational{b}
+    @eval Base.inv(::$Ta) = $b
+    @eval Base.literal_pow(::typeof(^), ::$Ta, ::Val{-1}) = $b
+    @eval Base.inv(::$Tb) = $a
+    @eval Base.literal_pow(::typeof(^), ::$Tb, ::Val{-1}) = $a
+    @eval Base.:(*)(::$Ta, ::$Tb) = _one($Ta)
+    @eval Base.:(*)(::$Tb, ::$Ta) = _one($Ta)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ end
   @test isapprox(4/pi, fourinvπ)
 end
 
-@testset "1/(k*pi)" begin  
+@testset "1/(k*pi)" begin
   @test isapprox(1/(2pi), inv2π)
   @test isapprox(1/(4pi), inv4π)
 end
@@ -38,3 +38,18 @@ end
   @test isapprox(log(4pi), log4π)
 end
 
+@testset "inv" begin
+  for (a,b) in [
+    (twoπ, inv2π),
+    (fourπ, inv4π),
+    (halfπ, twoinvπ),
+    (quartπ, fourinvπ),
+    (sqrt2π, invsqrt2π),
+    (sqrt2, invsqrt2),
+    ]
+    @test a^-1 == inv(a) == b
+    @test b^-1 == inv(b) == a
+    @test a*b == 1
+    @test b*a == 1
+  end
+end


### PR DESCRIPTION
Given that many of the constants defined here are reciprocals of each other, we may specialize `inv` and `literal_pow` to improve floating-point accuracy.

On main
```julia
ulia> sqrt2π*invsqrt2π
1.0000000000000002

julia> sqrt2*invsqrt2
1.0000000000000002
``` 

This PR
```julia
julia> sqrt2π*invsqrt2π == 1
true

julia> sqrt2*invsqrt2 == 1
true
```