### PR TITLE
Use `mpfr_const_log2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.1.0"
+version = "0.1.1"
 
 [compat]
 julia = "1"

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -24,7 +24,7 @@
 
 @irrational loghalf -0.6931471805599453094 log(inv(big(2)))
 @irrational logtwo  0.6931471805599453094 log2
-@irrational logten  2.302585092994046 log10
+@irrational logten  2.302585092994046 log10(big(π))
 @irrational logπ    1.1447298858494001741 log(big(π))
 @irrational log2π   1.8378770664093454836 log(2 * big(π))
 @irrational log4π   2.5310242469692907930 log(4 * big(π))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -22,7 +22,7 @@
 @irrational invsqrt2π 0.3989422804014326779 inv(sqrt(2 * big(π)))
 
 @irrational loghalf -0.6931471805599453094 log(inv(big(2)))
-@irrational logtwo 0.6931471805599453094 log(big(2))
+@irrational logtwo 0.6931471805599453094 log2
 @irrational logπ   1.1447298858494001741 log(big(π))
 @irrational log2π  1.8378770664093454836 log(2 * big(π))
 @irrational log4π  2.5310242469692907930 log(4 * big(π))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -24,7 +24,7 @@
 
 @irrational loghalf -0.6931471805599453094 log(inv(big(2)))
 @irrational logtwo  0.6931471805599453094 log2
-@irrational logten  2.302585092994046 log10(big(π))
+@irrational logten  2.302585092994046 log(big(10))
 @irrational logπ    1.1447298858494001741 log(big(π))
 @irrational log2π   1.8378770664093454836 log(2 * big(π))
 @irrational log4π   2.5310242469692907930 log(4 * big(π))


### PR DESCRIPTION
This PR changes the implementation of `logtwo` such that they use [`mpfr_const_log2`](https://www.mpfr.org/mpfr-current/mpfr.html#index-mpfr_005fconst_005flog2). The resulting definition for `BigFloat` is very similar to https://github.com/JuliaLang/julia/blob/f5d944c453c2cbfee1a1765f0d6a5fc38597494e/base/mpfr.jl#L620-L624 but additionally it is possible to specify precision and rounding mode:
```julia
julia> @macroexpand Base.@irrational logtwo 0.6931471805599453094 log2
quote
    #= irrationals.jl:187 =#
    const logtwo = Base.Irrational{:logtwo}()
    #= irrationals.jl:188 =#
    begin
        #= irrationals.jl:173 =#
        function (Base.Base).BigFloat(::Base.Irrational{:logtwo}, var"#97#r"::(Base.MPFR).MPFRRoundingMode = (Base.MPFR).ROUNDING_MODE[]; precision = precision(Base.BigFloat))
            #= irrationals.jl:173 =#
            #= irrationals.jl:174 =#
            var"#95#c" = Base.BigFloat(; precision = precision)
            #= irrationals.jl:175 =#
            ccall(("mpfr_const_log2", :libmpfr), Base.Cint, (Base.Ref{Base.BigFloat}, (Base.MPFR).MPFRRoundingMode), var"#95#c", var"#97#r")
            #= irrationals.jl:177 =#
            return var"#95#c"
        end
    end
    #= irrationals.jl:189 =#
    (Base.Base).Float64(::Base.Irrational{:logtwo}) = begin
            #= irrationals.jl:189 =#
            0.6931471805599453
        end
    #= irrationals.jl:190 =#
    (Base.Base).Float32(::Base.Irrational{:logtwo}) = begin
            #= irrationals.jl:190 =#
            0.6931472f0
        end
    #= irrationals.jl:191 =#
    if Base.big(logtwo) isa Base.BigFloat
        nothing
    else
        Base.throw(Base.AssertionError("big(\$(Expr(:escape, :logtwo))) isa BigFloat"))
    end
    #= irrationals.jl:192 =#
    if Base.Float64(logtwo) == Base.Float64(Base.big(logtwo))
        nothing
    else
        Base.throw(Base.AssertionError("Float64(\$(Expr(:escape, :logtwo))) == Float64(big(\$(Expr(:escape, :logtwo))))"))
    end
    #= irrationals.jl:193 =#
    if Base.Float32(logtwo) == Base.Float32(Base.big(logtwo))
        nothing
    else
        Base.throw(Base.AssertionError("Float32(\$(Expr(:escape, :logtwo))) == Float32(big(\$(Expr(:escape, :logtwo))))"))
    end
end
```