### PR TITLE
Fix `inv(sqrt(pi))` and add missing exports

### DIFF
--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -19,9 +19,11 @@ export
     sqrt4π,     # √4π
     sqrthalfπ,  # √(π / 2)
     invsqrt2,   # 1 / √2
+    invsqrtπ,   # 1 / √π
     invsqrt2π,  # 1 / √2π
     loghalf,    # log(1 / 2)
     logtwo,     # log(2)
+    logten,     # log(10)
     logπ,       # log(π)
     log2π,      # log(2π)
     log4π       # log(4π)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -19,7 +19,7 @@
 @irrational sqrthalfπ 1.2533141373155002512 sqrt(big(π) / 2)
 
 @irrational invsqrt2  0.7071067811865475244 inv(sqrt(big(2)))
-@irrational invsqrtπ  1.1283791670955126 inv(sqrt(big(π)))
+@irrational invsqrtπ  0.5641895835477563 inv(sqrt(big(π)))
 @irrational invsqrt2π 0.3989422804014326779 inv(sqrt(2 * big(π)))
 
 @irrational loghalf -0.6931471805599453094 log(inv(big(2)))


### PR DESCRIPTION
https://github.com/JuliaMath/IrrationalConstants.jl/pull/6 was all green but it seems tests did not run. This PR should fix the incorrect value of `inv(sqrt(pi))` and adds missing exports.

cc: @torfjelde 