### PR TITLE
Lambert's Omega constant

### DIFF
--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -29,7 +29,7 @@ export
     log4π,      # log(4π)
     invℯ, inve, # 1 / ℯ
 
-    lambertw_Ω, lambertw_Omega  # Ω exp(Ω) = 1
+    LambertW    # module that defines Lambert'W Ω: Ω*exp(Ω) = 1
 
 include("stats.jl")
 include("lambertw_omega.jl")

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -29,7 +29,7 @@ export
     log4π,      # log(4π)
     invℯ, inve, # 1 / ℯ
 
-    LambertW_Ω  # Ω exp(Ω) = 1
+    lambertw_Ω, lambertw_Omega  # Ω exp(Ω) = 1
 
 include("stats.jl")
 include("lambertw_omega.jl")

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -27,8 +27,11 @@ export
     logπ,       # log(π)
     log2π,      # log(2π)
     log4π,      # log(4π)
-    invℯ        # 1 / ℯ
+    invℯ,       # 1 / ℯ
+
+    LambertW_Ω  # Ω exp(Ω) = 1
 
 include("stats.jl")
+include("lambertw_omega.jl")
 
 end # module

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -27,7 +27,7 @@ export
     logπ,       # log(π)
     log2π,      # log(2π)
     log4π,      # log(4π)
-    invℯ,       # 1 / ℯ
+    invℯ, inve, # 1 / ℯ
 
     LambertW_Ω  # Ω exp(Ω) = 1
 

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -26,7 +26,8 @@ export
     logten,     # log(10)
     logπ,       # log(π)
     log2π,      # log(2π)
-    log4π       # log(4π)
+    log4π,      # log(4π)
+    invℯ        # 1 / ℯ
 
 include("stats.jl")
 

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -1,12 +1,12 @@
 # lazy-initialized LambertW Omega at 256-bit precision
-const LambertW_Omega_BigFloat256 = Ref{BigFloat}()
+const lambertw_Omega_BigFloat256 = Ref{BigFloat}()
 
 # compute BigFloat Omega constant at arbitrary precision
-function compute_LambertW_Omega()
-    # initialize Omega_BigFloat256
-    isassigned(LambertW_Omega_BigFloat256) ||
-        (LambertW_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194"))
-    o = LambertW_Omega_BigFloat256[] # initial value
+function compute_lambertw_Omega()
+    # initialize lambertw_Omega_BigFloat256
+    isassigned(lambertw_Omega_BigFloat256) ||
+        (lambertw_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194"))
+    o = lambertw_Omega_BigFloat256[] # initial value
     precision(BigFloat) <= 256 && return o
     # iteratively improve the precision of the constant
     myeps = eps(BigFloat)
@@ -18,7 +18,8 @@ function compute_LambertW_Omega()
     return o
 end
 
-@irrational LambertW_Ω 0.567143290409783872999968662210355 compute_LambertW_Omega()
+@irrational lambertw_Ω 0.567143290409783872999968662210355 compute_lambertw_Omega()
+const lambertw_Omega = lambertw_Ω # ASCII alias
 
 """
 Lambert's Omega (Ω) constant, such that Ω exp(Ω) = 1.
@@ -28,5 +29,4 @@ Lambert's Omega (Ω) constant, such that Ω exp(Ω) = 1.
 # See
 https://en.wikipedia.org/wiki/Omega_constant
 """
-LambertW_Ω
-
+lambertw_Ω

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -22,11 +22,14 @@ end
 const lambertw_Omega = lambertw_Ω # ASCII alias
 
 """
-Lambert's Omega (Ω) constant, such that Ω exp(Ω) = 1.
+Lambert's Omega (*Ω*) constant.
 
-*W(Ω) = 1*, where *W(t) = t exp(t)* is the *Lambert's W function*.
+Lambert's *Ω* is the solution to *W(Ω) = 1* equation,
+where *W(t) = t exp(t)* is the
+[Lambert's *W* function](https://en.wikipedia.org/wiki/Lambert_W_function).
 
-# See
-https://en.wikipedia.org/wiki/Omega_constant
+# See also
+  * https://en.wikipedia.org/wiki/Omega_constant
+  * [`lambertw()`][@ref SpecialFunctions.lambertw]
 """
 lambertw_Ω

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -1,0 +1,32 @@
+# lazy-initialized LambertW Omega at 256-bit precision
+const LambertW_Omega_BigFloat256 = Ref{BigFloat}()
+
+# compute BigFloat Omega constant at arbitrary precision
+function compute_LambertW_Omega()
+    # initialize Omega_BigFloat256
+    isassigned(LambertW_Omega_BigFloat256) ||
+        (LambertW_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194"))
+    o = LambertW_Omega_BigFloat256[] # initial value
+    precision(BigFloat) <= 256 && return o
+    # iteratively improve the precision of the constant
+    myeps = eps(BigFloat)
+    for _ in 1:100
+        o_ = (1 + o) / (1 + exp(o))
+        abs(o - o_) <= myeps && break
+        o = o_
+    end
+    return o
+end
+
+@irrational LambertW_Ω 0.567143290409783872999968662210355 compute_LambertW_Omega()
+
+"""
+Lambert's Omega (Ω) constant, such that Ω exp(Ω) = 1.
+
+*W(Ω) = 1*, where *W(t) = t exp(t)* is the *Lambert's W function*.
+
+# See
+https://en.wikipedia.org/wiki/Omega_constant
+"""
+LambertW_Ω
+

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -6,7 +6,7 @@ function compute_lambertw_Omega()
     # initialize lambertw_Omega_BigFloat256
     isassigned(lambertw_Omega_BigFloat256) ||
         (lambertw_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194", 256))
-    o = BigFloat(lambertw_Omega_BigFloat256[]) # initial value with current precision
+    o = BigFloat(lambertw_Omega_BigFloat256[], precision(BigFloat)) # initial value with current precision
     precision(o) <= 256 && return o
     # iteratively improve the precision of the constant
     myeps = eps(BigFloat)

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -2,7 +2,8 @@
 function compute_lambertw_Omega()
     o = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194")
     precision(o) <= 256 && return o
-    # iteratively improve the precision of the constant
+    # iteratively improve the precision
+    # see https://en.wikipedia.org/wiki/Omega_constant#Computation
     myeps = eps(BigFloat)
     for _ in 1:100
         o_ = (1 + o) / (1 + exp(o))

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -5,11 +5,12 @@ function compute_lambertw_Omega()
     # iteratively improve the precision
     # see https://en.wikipedia.org/wiki/Omega_constant#Computation
     myeps = eps(BigFloat)
-    for _ in 1:100
+    for _ in 1:1000
         o_ = (1 + o) / (1 + exp(o))
-        abs(o - o_) <= myeps && break
+        abs(o - o_) <= myeps && return o
         o = o_
     end
+    @warn "lambertw_Omega precision is less than current BigFloat precision ($(precision(BigFloat)))"
     return o
 end
 

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -5,9 +5,9 @@ const lambertw_Omega_BigFloat256 = Ref{BigFloat}()
 function compute_lambertw_Omega()
     # initialize lambertw_Omega_BigFloat256
     isassigned(lambertw_Omega_BigFloat256) ||
-        (lambertw_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194"))
-    o = lambertw_Omega_BigFloat256[] # initial value
-    precision(BigFloat) <= 256 && return o
+        (lambertw_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194", 256))
+    o = BigFloat(lambertw_Omega_BigFloat256[]) # initial value with current precision
+    precision(o) <= 256 && return o
     # iteratively improve the precision of the constant
     myeps = eps(BigFloat)
     for _ in 1:100

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -10,12 +10,13 @@ function compute_lambertw_Omega()
         abs(o - o_) <= myeps && return o
         o = o_
     end
-    @warn "lambertw_Omega precision is less than current BigFloat precision ($(precision(BigFloat)))"
+    @warn "Omega precision is less than current BigFloat precision ($(precision(BigFloat)))"
     return o
 end
 
-@irrational lambertw_Ω 0.567143290409783872999968662210355 compute_lambertw_Omega()
-const lambertw_Omega = lambertw_Ω # ASCII alias
+@irrational lambertw_Omega 0.567143290409783872999968662210355 compute_lambertw_Omega()
+
+module LambertW
 
 """
 Lambert's Omega (*Ω*) constant.
@@ -28,4 +29,7 @@ where *W(t) = t exp(t)* is the
   * https://en.wikipedia.org/wiki/Omega_constant
   * [`lambertw()`][@ref SpecialFunctions.lambertw]
 """
-lambertw_Ω
+const Ω = parentmodule(@__MODULE__).lambertw_Omega
+const Omega = parentmodule(@__MODULE__).lambertw_Omega # ASCII alias
+
+end

--- a/src/lambertw_omega.jl
+++ b/src/lambertw_omega.jl
@@ -1,12 +1,6 @@
-# lazy-initialized LambertW Omega at 256-bit precision
-const lambertw_Omega_BigFloat256 = Ref{BigFloat}()
-
 # compute BigFloat Omega constant at arbitrary precision
 function compute_lambertw_Omega()
-    # initialize lambertw_Omega_BigFloat256
-    isassigned(lambertw_Omega_BigFloat256) ||
-        (lambertw_Omega_BigFloat256[] = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194", 256))
-    o = BigFloat(lambertw_Omega_BigFloat256[], precision(BigFloat)) # initial value with current precision
+    o = BigFloat("0.5671432904097838729999686622103555497538157871865125081351310792230457930866845666932194")
     precision(o) <= 256 && return o
     # iteratively improve the precision of the constant
     myeps = eps(BigFloat)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -28,3 +28,5 @@
 @irrational logπ    1.1447298858494001741 log(big(π))
 @irrational log2π   1.8378770664093454836 log(2 * big(π))
 @irrational log4π   2.5310242469692907930 log(4 * big(π))
+
+@irrational invℯ    0.367879441171442321595 inv(big(ℯ))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -30,3 +30,4 @@
 @irrational log4π   2.5310242469692907930 log(4 * big(π))
 
 @irrational invℯ    0.367879441171442321595 inv(big(ℯ))
+const inve = invℯ # ASCII alias

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,3 +40,6 @@ end
   @test isapprox(log(4pi), log4π)
 end
 
+@testset "1/e" begin
+  @test isapprox(invℯ, exp(-1))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,8 +49,20 @@ end
   @test isapprox(lambertw_Ω * exp(lambertw_Ω), 1)
   @test lambertw_Omega == lambertw_Ω
 
+  # lower than default precision
+  setprecision(BigFloat, 196) do
+    o = big(lambertw_Ω)
+    @test precision(o) == 196
+    @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
+
+    oalias = big(lambertw_Omega)
+    @test o == oalias
+  end
+
+  # higher than default precision
   setprecision(BigFloat, 2048) do
     o = big(lambertw_Ω)
+    @test precision(o) == 2048
     @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
 
     oalias = big(lambertw_Omega)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,10 +45,15 @@ end
   @test isapprox(inve, exp(-1))
 end
 
-@testset "LambertW_Omega" begin
-  @test isapprox(LambertW_Ω * exp(LambertW_Ω), 1)
+@testset "lambertw_Omega" begin
+  @test isapprox(lambertw_Ω * exp(lambertw_Ω), 1)
+  @test lambertw_Omega == lambertw_Ω
+
   setprecision(BigFloat, 2048) do
-    o = big(LambertW_Ω)
+    o = big(lambertw_Ω)
     @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
+
+    oalias = big(lambertw_Omega)
+    @test o == oalias
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ end
 
 @testset "1/e" begin
   @test isapprox(invℯ, exp(-1))
+  @test isapprox(inve, exp(-1))
 end
 
 @testset "LambertW_Omega" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,3 +43,11 @@ end
 @testset "1/e" begin
   @test isapprox(invℯ, exp(-1))
 end
+
+@testset "LambertW_Omega" begin
+  @test isapprox(LambertW_Ω * exp(LambertW_Ω), 1)
+  setprecision(BigFloat, 2048) do
+    o = big(LambertW_Ω)
+    @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,27 +45,27 @@ end
   @test isapprox(inve, exp(-1))
 end
 
-@testset "lambertw_Omega" begin
-  @test isapprox(lambertw_Ω * exp(lambertw_Ω), 1)
-  @test lambertw_Omega == lambertw_Ω
+@testset "LambertW.Omega" begin
+  @test isapprox(LambertW.Ω * exp(LambertW.Ω), 1)
+  @test LambertW.Omega === LambertW.Ω
 
   # lower than default precision
   setprecision(BigFloat, 196) do
-    o = big(lambertw_Ω)
+    o = big(LambertW.Ω)
     @test precision(o) == 196
     @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
 
-    oalias = big(lambertw_Omega)
+    oalias = big(LambertW.Omega)
     @test o == oalias
   end
 
   # higher than default precision
   setprecision(BigFloat, 2048) do
-    o = big(lambertw_Ω)
+    o = big(LambertW.Ω)
     @test precision(o) == 2048
     @test isapprox(o * exp(o), 1, atol=eps(BigFloat))
 
-    oalias = big(lambertw_Omega)
+    oalias = big(LambertW.Omega)
     @test o == oalias
   end
 end


### PR DESCRIPTION
Add Lambert's [Omega constant](https://en.wikipedia.org/wiki/Omega_constant) as a part of moving [*LambertW.jl*](https://github.com/jlapeyre/LambertW.jl) into [*SpecialFunctions.jl*](https://github.com/JuliaMath/SpecialFunctions.jl) (see JuliaMath/SpecialFunctions.jl/pull/84).

Also add the related `inve = exp(-1)` constant, since `-exp(-1)` is the branching point for *W_0(t)* and *W_{-1}(t)*.

cc @jlapeyre