### PR TITLE
Add 1/e constant

### DIFF
--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -27,7 +27,7 @@ export
     logπ,       # log(π)
     log2π,      # log(2π)
     log4π,      # log(4π)
-    invℯ        # 1 / ℯ
+    invℯ, inve # 1 / ℯ
 
 include("stats.jl")
 

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -26,7 +26,8 @@ export
     logten,     # log(10)
     logπ,       # log(π)
     log2π,      # log(2π)
-    log4π       # log(4π)
+    log4π,      # log(4π)
+    invℯ        # 1 / ℯ
 
 include("stats.jl")
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -28,3 +28,5 @@
 @irrational logπ    1.1447298858494001741 log(big(π))
 @irrational log2π   1.8378770664093454836 log(2 * big(π))
 @irrational log4π   2.5310242469692907930 log(4 * big(π))
+
+@irrational invℯ    0.367879441171442321595 inv(big(ℯ))

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -30,3 +30,4 @@
 @irrational log4π   2.5310242469692907930 log(4 * big(π))
 
 @irrational invℯ    0.367879441171442321595 inv(big(ℯ))
+const inve = invℯ # ASCII alias

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,3 +40,6 @@ end
   @test isapprox(log(4pi), log4π)
 end
 
+@testset "1/e" begin
+  @test isapprox(invℯ, exp(-1))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,4 +42,5 @@ end
 
 @testset "1/e" begin
   @test isapprox(invℯ, exp(-1))
+  @test isapprox(inve, exp(-1))
 end


### PR DESCRIPTION
Adds `inve = 1/e` constant (cherry-picked from #12). Required by JuliaMath/SpecialFunctions.jl/issues/371