### PR TITLE
Add exact rules for irrational numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,8 @@ version = "0.1.1"
 julia = "1"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Compat"]

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -29,5 +29,6 @@ export
     log4π       # log(4π)
 
 include("stats.jl")
+include("rules.jl")
 
 end # module

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -37,6 +37,7 @@ Base.sincos(::Irrational{:fourπ}) = (0.0, 1.0)
 Base.sin(::Irrational{:quartπ}) = invsqrt2
 Base.cos(::Irrational{:quartπ}) = invsqrt2
 Base.sincos(::Irrational{:quartπ}) = (invsqrt2, invsqrt2)
+Base.sin(::Irrational{:halfπ}) = 1.0
 
 ## Exponential
 Base.exp(::Irrational{:loghalf}) = 0.5

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,27 +1,31 @@
-## Multiplication
+## Square
 Base.:*(::Irrational{:sqrt2}, ::Irrational{:sqrt2}) = 2.0
 Base.:*(::Irrational{:sqrt3}, ::Irrational{:sqrt3}) = 3.0
 Base.:*(::Irrational{:sqrtπ}, ::Irrational{:sqrtπ}) = π
 Base.:*(::Irrational{:sqrt2π}, ::Irrational{:sqrt2π}) = twoπ
 Base.:*(::Irrational{:sqrt4π}, ::Irrational{:sqrt4π}) = fourπ
-Base.:*(::Irrational{:sqrt4π}, ::Irrational{:sqrt4π}) = fourπ
+Base.:*(::Irrational{:sqrthalfπ}, ::Irrational{:sqrthalfπ}) = halfπ
+Base.:*(::Irrational{:invsqrt2}, ::Irrational{:invsqrt2}) = 0.5
+Base.:*(::Irrational{:invsqrtπ}, ::Irrational{:invsqrtπ}) = invπ
+Base.:*(::Irrational{:invsqrt2π}, ::Irrational{:invsqrt2π}) = inv2π
 
 ## Inverse
-Base.inv(::Irrational{:invπ}) = π
-Base.inv(::Irrational{:twoinvπ}) = halfπ
-# Base.inv(::Irrational{:fourinvπ}) = π/4  # This is not necessary because the return value will be approximated floating-point number.
-Base.inv(::Irrational{:inv2π}) = twoπ
-Base.inv(::Irrational{:inv4π}) = fourπ
-Base.inv(::Irrational{:invsqrt2}) = sqrt2
-Base.inv(::Irrational{:invsqrtπ}) = sqrtπ
-Base.inv(::Irrational{:invsqrt2π}) = sqrt2π
 # Base.inv(::Irrational{:π}) = invπ  # Avoid type piracy
+Base.inv(::Irrational{:invπ}) = π
 Base.inv(::Irrational{:twoπ}) = inv2π
+Base.inv(::Irrational{:inv2π}) = twoπ
+Base.inv(::Irrational{:twoinvπ}) = halfπ
 Base.inv(::Irrational{:halfπ}) = twoinvπ
+Base.inv(::Irrational{:quartπ}) = fourinvπ
+Base.inv(::Irrational{:fourinvπ}) = quartπ
 Base.inv(::Irrational{:fourπ}) = inv4π
+Base.inv(::Irrational{:inv4π}) = fourπ
+Base.inv(::Irrational{:sqrt2π}) = invsqrt2π
+Base.inv(::Irrational{:invsqrt2π}) = sqrt2π
 Base.inv(::Irrational{:sqrt2}) = invsqrt2
-Base.inv(::Irrational{:sqrtπ}) = sqrtπ
-Base.inv(::Irrational{:sqrt2π}) = sqrt2π
+Base.inv(::Irrational{:invsqrt2}) = sqrt2
+Base.inv(::Irrational{:sqrtπ}) = invsqrtπ
+Base.inv(::Irrational{:invsqrtπ}) = sqrtπ
 
 ## Triangular
 Base.sin(::Irrational{:twoπ}) = 0.0
@@ -30,6 +34,9 @@ Base.sincos(::Irrational{:twoπ}) = (0.0, 1.0)
 Base.sin(::Irrational{:fourπ}) = 0.0
 Base.cos(::Irrational{:fourπ}) = 1.0
 Base.sincos(::Irrational{:fourπ}) = (0.0, 1.0)
+Base.sin(::Irrational{:quartπ}) = invsqrt2
+Base.cos(::Irrational{:quartπ}) = invsqrt2
+Base.sincos(::Irrational{:quartπ}) = (invsqrt2, invsqrt2)
 
 ## Exponential
 Base.exp(::Irrational{:loghalf}) = 0.5

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,5 +1,5 @@
 ## Square
-SQUARE_PAIR = (
+SQUARE_PAIRS = (
     (sqrt2, 2.0),
     (sqrt3, 3.0),
     (sqrtπ, π),
@@ -10,13 +10,13 @@ SQUARE_PAIR = (
     (invsqrtπ, invπ),
     (invsqrt2π, inv2π),
 )
-for (a,b) in SQUARE_PAIR
+for (a,b) in SQUARE_PAIRS
     Base.:(*)(::typeof(a), ::typeof(a)) = b
     Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = b
 end
 
 ## Inverse
-INVERSE_PAIR = (
+INVERSE_PAIRS = (
     (π, invπ),
     (twoπ, inv2π),
     (twoinvπ, halfπ),
@@ -26,7 +26,7 @@ INVERSE_PAIR = (
     (sqrt2, invsqrt2),
     (sqrtπ, invsqrtπ),
 )
-for (a,b) in INVERSE_PAIR
+for (a,b) in INVERSE_PAIRS
     if a !== π  # Avoid type piracy
         Base.inv(::typeof(a)) = b
         Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = b

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,39 +1,41 @@
 ## Square
-SQUARE_PAIRS = (
-    (sqrt2, 2.0),
-    (sqrt3, 3.0),
-    (sqrtπ, π),
-    (sqrt2π, twoπ),
-    (sqrt4π, fourπ),
-    (sqrthalfπ, halfπ),
-    (invsqrt2, 0.5),
-    (invsqrtπ, invπ),
-    (invsqrt2π, inv2π),
-)
-for (a,b) in SQUARE_PAIRS
-    Base.:(*)(::typeof(a), ::typeof(a)) = b
-    Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = b
+let SQUARE_PAIRS = (
+        (sqrt2, 2.0),
+        (sqrt3, 3.0),
+        (sqrtπ, π),
+        (sqrt2π, twoπ),
+        (sqrt4π, fourπ),
+        (sqrthalfπ, halfπ),
+        (invsqrt2, 0.5),
+        (invsqrtπ, invπ),
+        (invsqrt2π, inv2π),
+    )
+    for (a,b) in SQUARE_PAIRS
+        Base.:(*)(::typeof(a), ::typeof(a)) = b
+        Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = b
+    end
 end
 
 ## Inverse
-INVERSE_PAIRS = (
-    (π, invπ),
-    (twoπ, inv2π),
-    (twoinvπ, halfπ),
-    (quartπ, fourinvπ),
-    (fourπ, inv4π),
-    (sqrt2π, invsqrt2π),
-    (sqrt2, invsqrt2),
-    (sqrtπ, invsqrtπ),
-)
-for (a,b) in INVERSE_PAIRS
-    if a !== π  # Avoid type piracy
-        Base.inv(::typeof(a)) = b
-        Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = b
+let INVERSE_PAIRS = (
+        (π, invπ),
+        (twoπ, inv2π),
+        (twoinvπ, halfπ),
+        (quartπ, fourinvπ),
+        (fourπ, inv4π),
+        (sqrt2π, invsqrt2π),
+        (sqrt2, invsqrt2),
+        (sqrtπ, invsqrtπ),
+    )
+    for (a,b) in INVERSE_PAIRS
+        if a !== π  # Avoid type piracy
+            Base.inv(::typeof(a)) = b
+            Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = b
+        end
+        Base.inv(::typeof(b)) = a
+        Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = a
+        Base.:(*)(::typeof(a), ::typeof(b)) = one(Irrational)
     end
-    Base.inv(::typeof(b)) = a
-    Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = a
-    Base.:(*)(::typeof(a), ::typeof(b)) = one(Irrational)
 end
 
 ## Triangular

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -38,6 +38,8 @@ Base.sin(::Irrational{:quartπ}) = invsqrt2
 Base.cos(::Irrational{:quartπ}) = invsqrt2
 Base.sincos(::Irrational{:quartπ}) = (invsqrt2, invsqrt2)
 Base.sin(::Irrational{:halfπ}) = 1.0
+Base.cos(::Irrational{:halfπ}) = 0.0
+Base.sincos(::Irrational{:halfπ}) = (1.0, 0.0)
 
 ## Exponential
 Base.exp(::Irrational{:loghalf}) = 0.5

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,31 +1,40 @@
 ## Square
-Base.:*(::Irrational{:sqrt2}, ::Irrational{:sqrt2}) = 2.0
-Base.:*(::Irrational{:sqrt3}, ::Irrational{:sqrt3}) = 3.0
-Base.:*(::Irrational{:sqrtπ}, ::Irrational{:sqrtπ}) = π
-Base.:*(::Irrational{:sqrt2π}, ::Irrational{:sqrt2π}) = twoπ
-Base.:*(::Irrational{:sqrt4π}, ::Irrational{:sqrt4π}) = fourπ
-Base.:*(::Irrational{:sqrthalfπ}, ::Irrational{:sqrthalfπ}) = halfπ
-Base.:*(::Irrational{:invsqrt2}, ::Irrational{:invsqrt2}) = 0.5
-Base.:*(::Irrational{:invsqrtπ}, ::Irrational{:invsqrtπ}) = invπ
-Base.:*(::Irrational{:invsqrt2π}, ::Irrational{:invsqrt2π}) = inv2π
+SQUARE_PAIR = (
+    (sqrt2, 2.0),
+    (sqrt3, 3.0),
+    (sqrtπ, π),
+    (sqrt2π, twoπ),
+    (sqrt4π, fourπ),
+    (sqrthalfπ, halfπ),
+    (invsqrt2, 0.5),
+    (invsqrtπ, invπ),
+    (invsqrt2π, inv2π),
+)
+for (a,b) in SQUARE_PAIR
+    Base.:(*)(::typeof(a), ::typeof(a)) = b
+    Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = b
+end
 
 ## Inverse
-# Base.inv(::Irrational{:π}) = invπ  # Avoid type piracy
-Base.inv(::Irrational{:invπ}) = π
-Base.inv(::Irrational{:twoπ}) = inv2π
-Base.inv(::Irrational{:inv2π}) = twoπ
-Base.inv(::Irrational{:twoinvπ}) = halfπ
-Base.inv(::Irrational{:halfπ}) = twoinvπ
-Base.inv(::Irrational{:quartπ}) = fourinvπ
-Base.inv(::Irrational{:fourinvπ}) = quartπ
-Base.inv(::Irrational{:fourπ}) = inv4π
-Base.inv(::Irrational{:inv4π}) = fourπ
-Base.inv(::Irrational{:sqrt2π}) = invsqrt2π
-Base.inv(::Irrational{:invsqrt2π}) = sqrt2π
-Base.inv(::Irrational{:sqrt2}) = invsqrt2
-Base.inv(::Irrational{:invsqrt2}) = sqrt2
-Base.inv(::Irrational{:sqrtπ}) = invsqrtπ
-Base.inv(::Irrational{:invsqrtπ}) = sqrtπ
+INVERSE_PAIR = (
+    (π, invπ),
+    (twoπ, inv2π),
+    (twoinvπ, halfπ),
+    (quartπ, fourinvπ),
+    (fourπ, inv4π),
+    (sqrt2π, invsqrt2π),
+    (sqrt2, invsqrt2),
+    (sqrtπ, invsqrtπ),
+)
+for (a,b) in INVERSE_PAIR
+    if a !== π  # Avoid type piracy
+        Base.inv(::typeof(a)) = b
+        Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = b
+    end
+    Base.inv(::typeof(b)) = a
+    Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = a
+    Base.:(*)(::typeof(a), ::typeof(b)) = one(Irrational)
+end
 
 ## Triangular
 Base.sin(::Irrational{:twoπ}) = 0.0

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,0 +1,45 @@
+## Multiplication
+Base.:*(::Irrational{:sqrt2}, ::Irrational{:sqrt2}) = 2.0
+Base.:*(::Irrational{:sqrt3}, ::Irrational{:sqrt3}) = 3.0
+Base.:*(::Irrational{:sqrtπ}, ::Irrational{:sqrtπ}) = π
+Base.:*(::Irrational{:sqrt2π}, ::Irrational{:sqrt2π}) = twoπ
+Base.:*(::Irrational{:sqrt4π}, ::Irrational{:sqrt4π}) = fourπ
+Base.:*(::Irrational{:sqrt4π}, ::Irrational{:sqrt4π}) = fourπ
+
+## Inverse
+Base.inv(::Irrational{:invπ}) = π
+Base.inv(::Irrational{:twoinvπ}) = halfπ
+# Base.inv(::Irrational{:fourinvπ}) = π/4  # This is not necessary because the return value will be approximated floating-point number.
+Base.inv(::Irrational{:inv2π}) = twoπ
+Base.inv(::Irrational{:inv4π}) = fourπ
+Base.inv(::Irrational{:invsqrt2}) = sqrt2
+Base.inv(::Irrational{:invsqrtπ}) = sqrtπ
+Base.inv(::Irrational{:invsqrt2π}) = sqrt2π
+# Base.inv(::Irrational{:π}) = invπ  # Avoid type piracy
+Base.inv(::Irrational{:twoπ}) = inv2π
+Base.inv(::Irrational{:halfπ}) = twoinvπ
+Base.inv(::Irrational{:fourπ}) = inv4π
+Base.inv(::Irrational{:sqrt2}) = invsqrt2
+Base.inv(::Irrational{:sqrtπ}) = sqrtπ
+Base.inv(::Irrational{:sqrt2π}) = sqrt2π
+
+## Triangular
+Base.sin(::Irrational{:twoπ}) = 0.0
+Base.cos(::Irrational{:twoπ}) = 1.0
+Base.sincos(::Irrational{:twoπ}) = (0.0, 1.0)
+Base.sin(::Irrational{:fourπ}) = 0.0
+Base.cos(::Irrational{:fourπ}) = 1.0
+Base.sincos(::Irrational{:fourπ}) = (0.0, 1.0)
+
+## Exponential
+Base.exp(::Irrational{:loghalf}) = 0.5
+Base.exp(::Irrational{:logtwo}) = 2.0
+Base.exp(::Irrational{:logten}) = 10.0
+Base.exp(::Irrational{:logπ}) = π
+Base.exp(::Irrational{:log2π}) = twoπ
+Base.exp(::Irrational{:log4π}) = fourπ
+
+## Logarithm
+# Base.log(::Irrational{:π}) = logπ  # Avoid type piracy
+Base.log(::Irrational{:twoπ}) = log2π
+Base.log(::Irrational{:fourπ}) = log4π

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -36,6 +36,7 @@ let INVERSE_PAIRS = (
         Base.inv(::typeof(b)) = Float64(a)
         Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = Float64(a)
         Base.:(*)(::typeof(a), ::typeof(b)) = 1.0  # This can be one(Irrational).
+        Base.:(*)(::typeof(b), ::typeof(a)) = 1.0  # This can be one(Irrational).
     end
 end
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -11,8 +11,9 @@ let SQUARE_PAIRS = (
         (invsqrt2π, inv2π),
     )
     for (a,b) in SQUARE_PAIRS
-        Base.:(*)(::typeof(a), ::typeof(a)) = b
-        Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = b
+        # The output type can be Irrational, but we enforces Float64 for now.
+        Base.:(*)(::typeof(a), ::typeof(a)) = Float64(b)
+        Base.literal_pow(::typeof(^), ::typeof(a), ::Val{2}) = Float64(b)
     end
 end
 
@@ -29,12 +30,12 @@ let INVERSE_PAIRS = (
     )
     for (a,b) in INVERSE_PAIRS
         if a !== π  # Avoid type piracy
-            Base.inv(::typeof(a)) = b
-            Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = b
+            Base.inv(::typeof(a)) = Float64(b)
+            Base.literal_pow(::typeof(^), ::typeof(a), ::Val{-1}) = Float64(b)
         end
-        Base.inv(::typeof(b)) = a
-        Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = a
-        Base.:(*)(::typeof(a), ::typeof(b)) = one(Irrational)
+        Base.inv(::typeof(b)) = Float64(a)
+        Base.literal_pow(::typeof(^), ::typeof(b), ::Val{-1}) = Float64(a)
+        Base.:(*)(::typeof(a), ::typeof(b)) = 1.0  # This can be one(Irrational).
     end
 end
 
@@ -45,9 +46,9 @@ Base.sincos(::Irrational{:twoπ}) = (0.0, 1.0)
 Base.sin(::Irrational{:fourπ}) = 0.0
 Base.cos(::Irrational{:fourπ}) = 1.0
 Base.sincos(::Irrational{:fourπ}) = (0.0, 1.0)
-Base.sin(::Irrational{:quartπ}) = invsqrt2
-Base.cos(::Irrational{:quartπ}) = invsqrt2
-Base.sincos(::Irrational{:quartπ}) = (invsqrt2, invsqrt2)
+Base.sin(::Irrational{:quartπ}) = Float64(invsqrt2)
+Base.cos(::Irrational{:quartπ}) = Float64(invsqrt2)
+Base.sincos(::Irrational{:quartπ}) = (Float64(invsqrt2), Float64(invsqrt2))
 Base.sin(::Irrational{:halfπ}) = 1.0
 Base.cos(::Irrational{:halfπ}) = 0.0
 Base.sincos(::Irrational{:halfπ}) = (1.0, 0.0)
@@ -56,11 +57,11 @@ Base.sincos(::Irrational{:halfπ}) = (1.0, 0.0)
 Base.exp(::Irrational{:loghalf}) = 0.5
 Base.exp(::Irrational{:logtwo}) = 2.0
 Base.exp(::Irrational{:logten}) = 10.0
-Base.exp(::Irrational{:logπ}) = π
-Base.exp(::Irrational{:log2π}) = twoπ
-Base.exp(::Irrational{:log4π}) = fourπ
+Base.exp(::Irrational{:logπ}) = Float64(π)
+Base.exp(::Irrational{:log2π}) = Float64(twoπ)
+Base.exp(::Irrational{:log4π}) = Float64(fourπ)
 
 ## Logarithm
 # Base.log(::Irrational{:π}) = logπ  # Avoid type piracy
-Base.log(::Irrational{:twoπ}) = log2π
-Base.log(::Irrational{:fourπ}) = log4π
+Base.log(::Irrational{:twoπ}) = Float64(log2π)
+Base.log(::Irrational{:fourπ}) = Float64(log4π)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using IrrationalConstants
 using Test
+using Compat
 
 const IRRATIONALS = (
     twoπ,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,17 @@ const IRRATIONALS = (
     log4π,
 )
 
+const INVERSE_PAIRS = (
+    (π, invπ),
+    (twoπ, inv2π),
+    (twoinvπ, halfπ),
+    (quartπ, fourinvπ),
+    (fourπ, inv4π),
+    (sqrt2π, invsqrt2π),
+    (sqrt2, invsqrt2),
+    (sqrtπ, invsqrtπ),
+)
+
 function test_with_function(f, a::Irrational)
     b = f(a)
     @test b ≈ f(float(a)) atol=1e-14
@@ -114,4 +125,9 @@ end
         test_with_function(abs2, a)
         test_with_function(t->t^2, a)
     end
+end
+
+@testset "Multiplicative inverse for (a,b)" for (a,b) in INVERSE_PAIRS
+    @test a*b === 1.0
+    @test b*a === 1.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,16 @@ const IRRATIONALS = (
 )
 
 function test_with_function(f, a::Irrational)
-    @test f(a) ≈ f(float(a)) atol=1e-14
-    @test (f(a) .≈ IRRATIONALS) == (f(a) .=== IRRATIONALS)
+    b = f(a)
+    @test b ≈ f(float(a)) atol=1e-14
+
+    # If f(a) is approximately equal to a value in IRRATIONALS, f(a) should be Irrational.
+    @test (b .≈ IRRATIONALS) == (b .=== IRRATIONALS)
+
+    # If f(a) is close to integer, it should be a integer.
+    if abs(b - round(b)) < 1e-14
+        @test isinteger(b)
+    end
 end
 
 @testset "approximately equal" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,38 @@
 using IrrationalConstants
 using Test
 
+const IRRATIONALS = (
+    twoπ,
+    fourπ,
+    halfπ,
+    quartπ,
+    invπ,
+    twoinvπ,
+    fourinvπ,
+    inv2π,
+    inv4π,
+    sqrt2,
+    sqrt3,
+    sqrtπ,
+    sqrt2π,
+    sqrt4π,
+    sqrthalfπ,
+    invsqrt2,
+    invsqrtπ,
+    invsqrt2π,
+    loghalf,
+    logtwo,
+    logten,
+    logπ,
+    log2π,
+    log4π,
+)
+
+function test_with_function(f, a::Irrational)
+    @test f(a) ≈ f(float(a)) atol=1e-14
+    @test (f(a) .≈ IRRATIONALS) == (f(a) .=== IRRATIONALS)
+end
+
 @testset "approximately equal" begin
     @testset "k*pi" begin
         @test isapprox(2*pi, twoπ)
@@ -39,5 +71,31 @@ using Test
         @test isapprox(log(pi), logπ)
         @test isapprox(log(2pi), log2π)
         @test isapprox(log(4pi), log4π)
+    end
+end
+
+@testset "rules for $(a)" for a in IRRATIONALS
+    @testset "log" begin
+        if a > 0
+            test_with_function(log, a)
+        end
+    end
+
+    @testset "inv" begin
+        test_with_function(inv, a)
+    end
+
+    @testset "exp" begin
+        test_with_function(exp, a)
+    end
+
+    @testset "sin" begin
+        test_with_function(sin, a)
+        test_with_function(cos, a)
+        @test sincos(a) == (sin(a),cos(a))
+    end
+
+    @testset "square" begin
+        test_with_function(t->t*t, a)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,11 +86,14 @@ end
     @testset "log" begin
         if a > 0
             test_with_function(log, a)
+        else
+            @test_throws DomainError log(a)
         end
     end
 
     @testset "inv" begin
         test_with_function(inv, a)
+        test_with_function(t->t^-1, a)
     end
 
     @testset "exp" begin
@@ -105,5 +108,7 @@ end
 
     @testset "square" begin
         test_with_function(t->t*t, a)
+        test_with_function(abs2, a)
+        test_with_function(t->t^2, a)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
 end
 
 @testset "rules for $(a)" for a in IRRATIONALS
-    @testset "log" begin
+    @testset "Logarithm" begin
         if a > 0
             test_with_function(log, a)
         else
@@ -91,22 +91,22 @@ end
         end
     end
 
-    @testset "inv" begin
+    @testset "Inverse" begin
         test_with_function(inv, a)
         test_with_function(t->t^-1, a)
     end
 
-    @testset "exp" begin
+    @testset "Exponential" begin
         test_with_function(exp, a)
     end
 
-    @testset "sin" begin
+    @testset "Triangular" begin
         test_with_function(sin, a)
         test_with_function(cos, a)
         @test sincos(a) == (sin(a),cos(a))
     end
 
-    @testset "square" begin
+    @testset "Square" begin
         test_with_function(t->t*t, a)
         test_with_function(abs2, a)
         test_with_function(t->t^2, a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,42 +1,43 @@
 using IrrationalConstants
 using Test
 
-@testset "k*pi" begin
-  @test isapprox(2*pi, twoπ)
-  @test isapprox(4*pi, fourπ)
-  @test isapprox(pi/2, halfπ)
-  @test isapprox(pi/4, quartπ)
-end
+@testset "approximately equal" begin
+    @testset "k*pi" begin
+        @test isapprox(2*pi, twoπ)
+        @test isapprox(4*pi, fourπ)
+        @test isapprox(pi/2, halfπ)
+        @test isapprox(pi/4, quartπ)
+    end
 
-@testset "k/pi" begin
-  @test isapprox(1/pi, invπ)
-  @test isapprox(2/pi, twoinvπ)
-  @test isapprox(4/pi, fourinvπ)
-end
+    @testset "k/pi" begin
+        @test isapprox(1/pi, invπ)
+        @test isapprox(2/pi, twoinvπ)
+        @test isapprox(4/pi, fourinvπ)
+    end
 
-@testset "1/(k*pi)" begin  
-  @test isapprox(1/(2pi), inv2π)
-  @test isapprox(1/(4pi), inv4π)
-end
+    @testset "1/(k*pi)" begin
+        @test isapprox(1/(2pi), inv2π)
+        @test isapprox(1/(4pi), inv4π)
+    end
 
-@testset "sqrt" begin
-  @test isapprox(sqrt(2), sqrt2)
-  @test isapprox(sqrt(3), sqrt3)
-  @test isapprox(sqrt(pi), sqrtπ)
-  @test isapprox(sqrt(2pi), sqrt2π)
-  @test isapprox(sqrt(4pi), sqrt4π)
-  @test isapprox(sqrt(pi/2), sqrthalfπ)
-  @test isapprox(sqrt(1/2), invsqrt2)
-  @test isapprox(sqrt(1/(pi)), invsqrtπ)
-  @test isapprox(sqrt(1/(2pi)), invsqrt2π)
-end
+    @testset "sqrt" begin
+        @test isapprox(sqrt(2), sqrt2)
+        @test isapprox(sqrt(3), sqrt3)
+        @test isapprox(sqrt(pi), sqrtπ)
+        @test isapprox(sqrt(2pi), sqrt2π)
+        @test isapprox(sqrt(4pi), sqrt4π)
+        @test isapprox(sqrt(pi/2), sqrthalfπ)
+        @test isapprox(sqrt(1/2), invsqrt2)
+        @test isapprox(sqrt(1/(pi)), invsqrtπ)
+        @test isapprox(sqrt(1/(2pi)), invsqrt2π)
+    end
 
-@testset "log" begin
-  @test isapprox(log(1/2), loghalf)
-  @test isapprox(log(2), logtwo)
-  @test isapprox(log(10), logten)
-  @test isapprox(log(pi), logπ)
-  @test isapprox(log(2pi), log2π)
-  @test isapprox(log(4pi), log4π)
+    @testset "log" begin
+        @test isapprox(log(1/2), loghalf)
+        @test isapprox(log(2), logtwo)
+        @test isapprox(log(10), logten)
+        @test isapprox(log(pi), logπ)
+        @test isapprox(log(2pi), log2π)
+        @test isapprox(log(4pi), log4π)
+    end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,10 @@ function test_with_function(f, a::Irrational)
     b = f(a)
     @test b ≈ f(float(a)) atol=1e-14
 
-    # If f(a) is approximately equal to a value in IRRATIONALS, f(a) should be Irrational.
-    @test (b .≈ IRRATIONALS) == (b .=== IRRATIONALS)
+    # The output type can be Irrational, but we enforces Float64 for now.
+    # # If f(a) is approximately equal to a value in IRRATIONALS, f(a) should be Irrational.
+    # @test (b .≈ IRRATIONALS) == (b .=== IRRATIONALS)
+    @test b isa Float64
 
     # If f(a) is close to integer, it should be a integer.
     if abs(b - round(b)) < 1e-14


### PR DESCRIPTION
This PR fixes https://github.com/JuliaMath/IrrationalConstants.jl/issues/20, and is an alternative to JuliaMath/Tau.jl#7.

**On current master**
```julia
julia> sqrt2^2
2.0000000000000004

julia> sin(quartπ)
0.7071067811865475

julia> inv(quartπ)
1.2732395447351628
```

**With this PR**
```julia
julia> sqrt2^2
2.0

julia> sin(quartπ)
invsqrt2 = 0.7071067811865...

julia> inv(quartπ)
fourinvπ = 1.2732395447351...
```