### PR TITLE
Drop support under Julia v1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["JuliaMath"]
 version = "0.1.1"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Julia v1.6 is the new LTS, and v1.0 is no longer maintained. This PR replaces `v1.0` with `v1.6`.