### PR TITLE
Add trigonometric functions for special irrationals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.2.1"
+version = "0.2.2"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.2.0"
+version = "0.2.1"
 
 [compat]
 julia = "1"

--- a/src/IrrationalConstants.jl
+++ b/src/IrrationalConstants.jl
@@ -28,5 +28,6 @@ export
 
 include("macro.jl")
 include("stats.jl")
+include("trigonometric.jl")
 
 end # module

--- a/src/trigonometric.jl
+++ b/src/trigonometric.jl
@@ -27,3 +27,8 @@ Base.tan(::Twoπ) = 0.0
 Base.tan(::Fourπ) = 0.0
 Base.tan(::Halfπ) = 1/0
 Base.tan(::Quartπ) = 1.0
+
+# `csc`, `sec`, and `cot` are defined automatically, so we do not define them
+# there is one exception where we can improve accuracy:
+Base.csc(::Quartπ) = Float64(sqrt2)
+Base.sec(::Quartπ) = Float64(sqrt2)

--- a/src/trigonometric.jl
+++ b/src/trigonometric.jl
@@ -1,0 +1,29 @@
+# Functions return `Float64`, consistent with Base
+# https://github.com/JuliaLang/julia/pull/42595
+# Values at poles are defined to be consistent with `cot(0)` and `cot(π)`
+# https://github.com/JuliaLang/julia/issues/7123
+# https://github.com/JuliaLang/julia/blob/e3d366f1966595ba737220df49e220610823b331/base/mathconstants.jl#L130
+
+# `sin`
+Base.sin(::Twoπ) = 0.0
+Base.sin(::Fourπ) = 0.0
+Base.sin(::Halfπ) = 1.0
+Base.sin(::Quartπ) = Float64(invsqrt2)
+
+# `cos`
+Base.cos(::Twoπ) = 1.0
+Base.cos(::Fourπ) = 1.0
+Base.cos(::Halfπ) = 0.0
+Base.cos(::Quartπ) = Float64(invsqrt2)
+
+# `sincos`
+Base.sincos(::Twoπ) = (0.0, 1.0)
+Base.sincos(::Fourπ) = (0.0, 1.0)
+Base.sincos(::Halfπ) = (1.0, 0.0)
+Base.sincos(::Quartπ) = (Float64(invsqrt2), Float64(invsqrt2))
+
+# `tan`
+Base.tan(::Twoπ) = 0.0
+Base.tan(::Fourπ) = 0.0
+Base.tan(::Halfπ) = 1/0
+Base.tan(::Quartπ) = 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,26 +152,26 @@ end
 end
 
 @testset "trigonometric functions" begin
-  # 2π, 4π
-  for (n, x) in ((2, twoπ), (4, fourπ))
-    @test sin(x) === sinpi(n) === sin(0.0)
-    @test cos(x) === cospi(n) === cos(0.0)
-  end
+    # 2π, 4π
+    for (n, x) in ((2, twoπ), (4, fourπ))
+        @test sin(x) === sinpi(n) === sin(0.0) === Float64(sin(big(x)))
+        @test cos(x) === cospi(n) === cos(0.0) === Float64(cos(big(x)))
+    end
 
-  # halfπ, quartπ
-  for (r, x) in ((big"0.5", halfπ), (big"0.25", quartπ))
-    @test sin(x) === Float64(sinpi(r))
-    @test cos(x) === Float64(cospi(r))
-  end
+    # halfπ, quartπ
+    for (r, x) in ((big"0.5", halfπ), (big"0.25", quartπ))
+        @test sin(x) === Float64(sinpi(r))
+        @test cos(x) === Float64(cospi(r))
+    end
 
-  for x in (twoπ, fourπ, halfπ, quartπ)
-    # Check consistency of definitions
-    @test sincos(x) === (sin(x), cos(x))
-    @test tan(x) === sin(x) / cos(x)
+    for x in (twoπ, fourπ, halfπ, quartπ)
+        # Check consistency of definitions
+        @test sincos(x) === (sin(x), cos(x))
+        @test tan(x) === sin(x) / cos(x)
 
-    # These are defined automatically via sin, cos, and tan
-    @test csc(x) === inv(sin(x))
-    @test sec(x) === inv(cos(x))
-    @test cot(x) === inv(tan(x))
-  end
+        # These are defined automatically via sin, cos, and tan
+        @test csc(x) === Float64(csc(big(x)))
+        @test sec(x) === Float64(sec(big(x)))
+        @test cot(x) === csc(x) / sec(x)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,9 +144,9 @@ end
   end
 
   # halfπ, quartπ
-  for (r, x) in ((1 // 2, halfπ), (1 // 4, quartπ))
-    @test sin(x) === sinpi(r)
-    @test cos(x) === cospi(r)
+  for (r, x) in ((big"0.5", halfπ), (big"0.25", quartπ))
+    @test sin(x) === Float64(sinpi(r))
+    @test cos(x) === Float64(cospi(r))
   end
 
   for x in (twoπ, fourπ, halfπ, quartπ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,8 +154,8 @@ end
 @testset "trigonometric functions" begin
     # 2π, 4π
     for (n, x) in ((2, twoπ), (4, fourπ))
-        @test sin(x) === sinpi(n) === sin(0.0) === Float64(sin(big(x)))
-        @test cos(x) === cospi(n) === cos(0.0) === Float64(cos(big(x)))
+        @test sin(x) === sinpi(n) === sin(0.0)
+        @test cos(x) === cospi(n) === cos(0.0)
     end
 
     # halfπ, quartπ
@@ -164,14 +164,20 @@ end
         @test cos(x) === Float64(cospi(r))
     end
 
+    # Check consistency of definitions
     for x in (twoπ, fourπ, halfπ, quartπ)
-        # Check consistency of definitions
         @test sincos(x) === (sin(x), cos(x))
         @test tan(x) === sin(x) / cos(x)
+    end
 
+    # Check `csc`, `sec`, and `cot`
+    for x in (twoπ, fourπ, halfπ)
         # These are defined automatically via sin, cos, and tan
-        @test csc(x) === Float64(csc(big(x)))
-        @test sec(x) === Float64(sec(big(x)))
+        @test csc(x) === 1 / sin(x)
+        @test sec(x) === 1 / cos(x)
         @test cot(x) === csc(x) / sec(x)
     end
+    @test csc(quartπ) === Float64(csc(big(quartπ)))
+    @test sec(quartπ) === Float64(sec(big(quartπ)))
+    @test cot(quartπ) === Float64(cot(big(quartπ)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,3 +135,28 @@ end
   @test twoπ/ComplexF32(2) isa ComplexF32
   @test log(twoπ, ComplexF32(2)) isa ComplexF32
 end
+
+@testset "trigonometric functions" begin
+  # 2π, 4π
+  for (n, x) in ((2, twoπ), (4, fourπ))
+    @test sin(x) === sinpi(n) === sin(0.0)
+    @test cos(x) === cospi(n) === cos(0.0)
+  end
+
+  # halfπ, quartπ
+  for (r, x) in ((1 // 2, halfπ), (1 // 4, quartπ))
+    @test sin(x) === sinpi(r)
+    @test cos(x) === cospi(r)
+  end
+
+  for x in (twoπ, fourπ, halfπ, quartπ)
+    # Check consistency of definitions
+    @test sincos(x) === (sin(x), cos(x))
+    @test tan(x) === sin(x) / cos(x)
+
+    # These are defined automatically via sin, cos, and tan
+    @test csc(x) === inv(sin(x)) === csc(0.0)
+    @test sec(x) === inv(cos(x)) === sec(0.0)
+    @test cot(x) === inv(tan(x)) === cot(0.0)
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,8 +155,8 @@ end
     @test tan(x) === sin(x) / cos(x)
 
     # These are defined automatically via sin, cos, and tan
-    @test csc(x) === inv(sin(x)) === csc(0.0)
-    @test sec(x) === inv(cos(x)) === sec(0.0)
-    @test cot(x) === inv(tan(x)) === cot(0.0)
+    @test csc(x) === inv(sin(x))
+    @test sec(x) === inv(cos(x))
+    @test cot(x) === inv(tan(x))
   end
 end


### PR DESCRIPTION
Fixes #20.

This PR is a (largely) reduced and updated version of #14. Arguably it is quite uncontroversial since it just matches the existing behaviour of `sin(pi)` etc. in Base: https://github.com/JuliaLang/julia/pull/42595