### PR TITLE
Use four spaces indent in `test/runtests.jl`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,135 +3,135 @@ using Documenter
 using Test
 
 @testset "k*pi" begin
-  @test isapprox(2*pi, twoπ)
-  @test isapprox(4*pi, fourπ)
-  @test isapprox(pi/2, halfπ)
-  @test isapprox(pi/4, quartπ)
+    @test isapprox(2*pi, twoπ)
+    @test isapprox(4*pi, fourπ)
+    @test isapprox(pi/2, halfπ)
+    @test isapprox(pi/4, quartπ)
 end
 
 @testset "k/pi" begin
-  @test isapprox(1/pi, invπ)
-  @test isapprox(2/pi, twoinvπ)
-  @test isapprox(4/pi, fourinvπ)
+    @test isapprox(1/pi, invπ)
+    @test isapprox(2/pi, twoinvπ)
+    @test isapprox(4/pi, fourinvπ)
 end
 
 @testset "1/(k*pi)" begin  
-  @test isapprox(1/(2pi), inv2π)
-  @test isapprox(1/(4pi), inv4π)
+    @test isapprox(1/(2pi), inv2π)
+    @test isapprox(1/(4pi), inv4π)
 end
 
 @testset "sqrt" begin
-  @test isapprox(sqrt(2), sqrt2)
-  @test isapprox(sqrt(3), sqrt3)
-  @test isapprox(sqrt(pi), sqrtπ)
-  @test isapprox(sqrt(2pi), sqrt2π)
-  @test isapprox(sqrt(4pi), sqrt4π)
-  @test isapprox(sqrt(pi/2), sqrthalfπ)
-  @test isapprox(sqrt(1/2), invsqrt2)
-  @test isapprox(sqrt(1/(pi)), invsqrtπ)
-  @test isapprox(sqrt(1/(2pi)), invsqrt2π)
+    @test isapprox(sqrt(2), sqrt2)
+    @test isapprox(sqrt(3), sqrt3)
+    @test isapprox(sqrt(pi), sqrtπ)
+    @test isapprox(sqrt(2pi), sqrt2π)
+    @test isapprox(sqrt(4pi), sqrt4π)
+    @test isapprox(sqrt(pi/2), sqrthalfπ)
+    @test isapprox(sqrt(1/2), invsqrt2)
+    @test isapprox(sqrt(1/(pi)), invsqrtπ)
+    @test isapprox(sqrt(1/(2pi)), invsqrt2π)
 end
 
 @testset "log" begin
-  @test isapprox(log(1/2), loghalf)
-  @test isapprox(log(2), logtwo)
-  @test isapprox(log(10), logten)
-  @test isapprox(log(pi), logπ)
-  @test isapprox(log(2pi), log2π)
-  @test isapprox(log(4pi), log4π)
+    @test isapprox(log(1/2), loghalf)
+    @test isapprox(log(2), logtwo)
+    @test isapprox(log(10), logten)
+    @test isapprox(log(pi), logπ)
+    @test isapprox(log(2pi), log2π)
+    @test isapprox(log(4pi), log4π)
 end
 
 @testset "type system" begin
-  @test twoπ === IrrationalConstants.Twoπ()
-  @test twoπ isa IrrationalConstants.IrrationalConstant
-  @test twoπ isa AbstractIrrational
+    @test twoπ === IrrationalConstants.Twoπ()
+    @test twoπ isa IrrationalConstants.IrrationalConstant
+    @test twoπ isa AbstractIrrational
 end
 
 @testset "hash" begin
-  for i in (twoπ, invπ, sqrt2, logtwo)
-    for j in (twoπ, invπ, sqrt2, logtwo)
-      @test isequal(i==j, hash(i)==hash(j))
+    for i in (twoπ, invπ, sqrt2, logtwo)
+        for j in (twoπ, invπ, sqrt2, logtwo)
+            @test isequal(i==j, hash(i)==hash(j))
+        end
     end
-  end
 end
 
 @testset "doctests" begin
-  DocMeta.setdocmeta!(
+    DocMeta.setdocmeta!(
     IrrationalConstants, :DocTestSetup, :(using IrrationalConstants); recursive=true
-  )
-  doctest(IrrationalConstants; manual=false)
+    )
+    doctest(IrrationalConstants; manual=false)
 end
 
 # copied from https://github.com/JuliaLang/julia/blob/cf5ae0369ceae078cf6a29d7aa34f48a5a53531e/test/numbers.jl
 # and adapted to irrationals in this package
 
 @testset "IrrationalConstant zero and one" begin
-  @test one(twoπ) === true
-  @test zero(twoπ) === false
-  @test one(typeof(twoπ)) === true
-  @test zero(typeof(twoπ)) === false
+    @test one(twoπ) === true
+    @test zero(twoπ) === false
+    @test one(typeof(twoπ)) === true
+    @test zero(typeof(twoπ)) === false
 end
 
 @testset "IrrationalConstants compared with IrrationalConstants" begin
-  for i in (twoπ, invπ, sqrt2, logtwo)
-    for j in (twoπ, invπ, sqrt2, logtwo)
-      @test isequal(i==j, Float64(i)==Float64(j))
-      @test isequal(i!=j, Float64(i)!=Float64(j))
-      @test isequal(i<=j, Float64(i)<=Float64(j))
-      @test isequal(i>=j, Float64(i)>=Float64(j))
-      @test isequal(i<j, Float64(i)<Float64(j))
-      @test isequal(i>j, Float64(i)>Float64(j))
+    for i in (twoπ, invπ, sqrt2, logtwo)
+        for j in (twoπ, invπ, sqrt2, logtwo)
+            @test isequal(i==j, Float64(i)==Float64(j))
+            @test isequal(i!=j, Float64(i)!=Float64(j))
+            @test isequal(i<=j, Float64(i)<=Float64(j))
+            @test isequal(i>=j, Float64(i)>=Float64(j))
+            @test isequal(i<j, Float64(i)<Float64(j))
+            @test isequal(i>j, Float64(i)>Float64(j))
+        end
     end
-  end
 end
 
 @testset "IrrationalConstant Inverses, JuliaLang/Julia Issue #30882" begin
-  @test @inferred(inv(twoπ)) ≈ 0.15915494309189535
+    @test @inferred(inv(twoπ)) ≈ 0.15915494309189535
 end
 
 @testset "IrrationalConstants compared with Rationals and Floats" begin
-  @test Float64(twoπ, RoundDown) < twoπ
-  @test Float64(twoπ, RoundUp) > twoπ
-  @test !(Float64(twoπ, RoundDown) > twoπ)
-  @test !(Float64(twoπ, RoundUp) < twoπ)
-  @test Float64(twoπ, RoundDown) <= twoπ
-  @test Float64(twoπ, RoundUp) >= twoπ
-  @test Float64(twoπ, RoundDown) != twoπ
-  @test Float64(twoπ, RoundUp) != twoπ
+    @test Float64(twoπ, RoundDown) < twoπ
+    @test Float64(twoπ, RoundUp) > twoπ
+    @test !(Float64(twoπ, RoundDown) > twoπ)
+    @test !(Float64(twoπ, RoundUp) < twoπ)
+    @test Float64(twoπ, RoundDown) <= twoπ
+    @test Float64(twoπ, RoundUp) >= twoπ
+    @test Float64(twoπ, RoundDown) != twoπ
+    @test Float64(twoπ, RoundUp) != twoπ
 
-  @test Float32(twoπ, RoundDown) < twoπ
-  @test Float32(twoπ, RoundUp) > twoπ
-  @test !(Float32(twoπ, RoundDown) > twoπ)
-  @test !(Float32(twoπ, RoundUp) < twoπ)
+    @test Float32(twoπ, RoundDown) < twoπ
+    @test Float32(twoπ, RoundUp) > twoπ
+    @test !(Float32(twoπ, RoundDown) > twoπ)
+    @test !(Float32(twoπ, RoundUp) < twoπ)
 
-  @test prevfloat(big(twoπ)) < twoπ
-  @test nextfloat(big(twoπ)) > twoπ
-  @test !(prevfloat(big(twoπ)) > twoπ)
-  @test !(nextfloat(big(twoπ)) < twoπ)
+    @test prevfloat(big(twoπ)) < twoπ
+    @test nextfloat(big(twoπ)) > twoπ
+    @test !(prevfloat(big(twoπ)) > twoπ)
+    @test !(nextfloat(big(twoπ)) < twoπ)
 
-  @test 5293386250278608690//842468587426513207 < twoπ
-  @test !(5293386250278608690//842468587426513207 > twoπ)
-  @test 5293386250278608690//842468587426513207 != twoπ
+    @test 5293386250278608690//842468587426513207 < twoπ
+    @test !(5293386250278608690//842468587426513207 > twoπ)
+    @test 5293386250278608690//842468587426513207 != twoπ
 end
 IrrationalConstants.@irrational i46051 4863.185427757 1548big(pi)
 @testset "IrrationalConstant printing" begin
-  @test sprint(show, "text/plain", twoπ) == "twoπ = 6.2831853071795..."
-  @test sprint(show, "text/plain", twoπ, context=:compact => true) == "twoπ"
-  @test sprint(show, twoπ) == "twoπ"
-  # JuliaLang/Julia issue #46051
-  @test sprint(show, "text/plain", i46051) == "i46051 = 4863.185427757..."
+    @test sprint(show, "text/plain", twoπ) == "twoπ = 6.2831853071795..."
+    @test sprint(show, "text/plain", twoπ, context=:compact => true) == "twoπ"
+    @test sprint(show, twoπ) == "twoπ"
+    # JuliaLang/Julia issue #46051
+    @test sprint(show, "text/plain", i46051) == "i46051 = 4863.185427757..."
 end
 
 @testset "IrrationalConstant/Bool multiplication" begin
-  @test false*twoπ === 0.0
-  @test twoπ*false === 0.0
-  @test true*twoπ === Float64(twoπ)
-  @test twoπ*true === Float64(twoπ)
+    @test false*twoπ === 0.0
+    @test twoπ*false === 0.0
+    @test true*twoπ === Float64(twoπ)
+    @test twoπ*true === Float64(twoπ)
 end
 
 # JuliaLang/Julia issue #26324
 @testset "irrational promotion" begin
-  @test twoπ*ComplexF32(2) isa ComplexF32
-  @test twoπ/ComplexF32(2) isa ComplexF32
-  @test log(twoπ, ComplexF32(2)) isa ComplexF32
+    @test twoπ*ComplexF32(2) isa ComplexF32
+    @test twoπ/ComplexF32(2) isa ComplexF32
+    @test log(twoπ, ComplexF32(2)) isa ComplexF32
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,15 +71,13 @@ end
 end
 
 @testset "IrrationalConstants compared with IrrationalConstants" begin
-    for i in (twoπ, invπ, sqrt2, logtwo)
-        for j in (twoπ, invπ, sqrt2, logtwo)
-            @test isequal(i==j, Float64(i)==Float64(j))
-            @test isequal(i!=j, Float64(i)!=Float64(j))
-            @test isequal(i<=j, Float64(i)<=Float64(j))
-            @test isequal(i>=j, Float64(i)>=Float64(j))
-            @test isequal(i<j, Float64(i)<Float64(j))
-            @test isequal(i>j, Float64(i)>Float64(j))
-        end
+    for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
+        @test isequal(i==j, Float64(i)==Float64(j))
+        @test isequal(i!=j, Float64(i)!=Float64(j))
+        @test isequal(i<=j, Float64(i)<=Float64(j))
+        @test isequal(i>=j, Float64(i)>=Float64(j))
+        @test isequal(i<j, Float64(i)<Float64(j))
+        @test isequal(i>j, Float64(i)>Float64(j))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,10 +48,8 @@ end
 end
 
 @testset "hash" begin
-    for i in (twoπ, invπ, sqrt2, logtwo)
-        for j in (twoπ, invπ, sqrt2, logtwo)
-            @test isequal(i==j, hash(i)==hash(j))
-        end
+    for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
+        @test isequal(i==j, hash(i)==hash(j))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ end
 
 @testset "doctests" begin
     DocMeta.setdocmeta!(
-    IrrationalConstants, :DocTestSetup, :(using IrrationalConstants); recursive=true
+        IrrationalConstants, :DocTestSetup, :(using IrrationalConstants); recursive=true
     )
     doctest(IrrationalConstants; manual=false)
 end


### PR DESCRIPTION
This PR fixes indents as reported in https://github.com/JuliaMath/IrrationalConstants.jl/pull/19#pullrequestreview-1305764737.