### PR TITLE
Add `Base.round(x::IrrationalConstant, r::RoundingMode)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.2.0"
+version = "0.2.1"
 
 [compat]
 julia = "1"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -16,6 +16,7 @@ Base.:(==)(::T, ::T) where {T<:IrrationalConstant} = true
 Base.:<(::T, ::T) where {T<:IrrationalConstant} = false
 Base.:<=(::T, ::T) where {T<:IrrationalConstant} = true
 Base.hash(x::IrrationalConstant, h::UInt) = 3*objectid(x) - h
+Base.round(x::IrrationalConstant, r::RoundingMode) = round(float(x), r)
 
 # definitions for AbstractIrrational added in https://github.com/JuliaLang/julia/pull/34773
 if VERSION < v"1.5.0-DEV.301"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -4,6 +4,8 @@
 
 abstract type IrrationalConstant <: AbstractIrrational end
 
+# TODO: Remove definitions if they become available for `AbstractIrrational` in Base
+# Ref https://github.com/JuliaLang/julia/pull/48768
 function Base.show(io::IO, ::MIME"text/plain", x::IrrationalConstant)
     if get(io, :compact, false)::Bool
         print(io, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,3 +131,15 @@ end
     @test twoπ/ComplexF32(2) isa ComplexF32
     @test log(twoπ, ComplexF32(2)) isa ComplexF32
 end
+
+# issue #23
+@testset "rounding irrationals" begin
+    for mode in (RoundDown, RoundToZero, RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
+        @test @inferred(round(twoπ, mode)) == 6.0
+        @test @inferred(round(sqrt2, mode)) == 1.0
+    end
+    @test @inferred(round(sqrt3, RoundUp)) == 2.0
+    for mode in (RoundUp, RoundToZero)
+        @test @inferred(round(loghalf, mode)) == 0.0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,21 +3,21 @@ using Documenter
 using Test
 
 @testset "k*pi" begin
-    @test isapprox(2 * pi, twoπ)
-    @test isapprox(4 * pi, fourπ)
-    @test isapprox(pi / 2, halfπ)
-    @test isapprox(pi / 4, quartπ)
+    @test isapprox(2*pi, twoπ)
+    @test isapprox(4*pi, fourπ)
+    @test isapprox(pi/2, halfπ)
+    @test isapprox(pi/4, quartπ)
 end
 
 @testset "k/pi" begin
-    @test isapprox(1 / pi, invπ)
-    @test isapprox(2 / pi, twoinvπ)
-    @test isapprox(4 / pi, fourinvπ)
+    @test isapprox(1/pi, invπ)
+    @test isapprox(2/pi, twoinvπ)
+    @test isapprox(4/pi, fourinvπ)
 end
 
-@testset "1/(k*pi)" begin
-    @test isapprox(1 / (2pi), inv2π)
-    @test isapprox(1 / (4pi), inv4π)
+@testset "1/(k*pi)" begin  
+    @test isapprox(1/(2pi), inv2π)
+    @test isapprox(1/(4pi), inv4π)
 end
 
 @testset "sqrt" begin
@@ -26,14 +26,14 @@ end
     @test isapprox(sqrt(pi), sqrtπ)
     @test isapprox(sqrt(2pi), sqrt2π)
     @test isapprox(sqrt(4pi), sqrt4π)
-    @test isapprox(sqrt(pi / 2), sqrthalfπ)
-    @test isapprox(sqrt(1 / 2), invsqrt2)
-    @test isapprox(sqrt(1 / (pi)), invsqrtπ)
-    @test isapprox(sqrt(1 / (2pi)), invsqrt2π)
+    @test isapprox(sqrt(pi/2), sqrthalfπ)
+    @test isapprox(sqrt(1/2), invsqrt2)
+    @test isapprox(sqrt(1/(pi)), invsqrtπ)
+    @test isapprox(sqrt(1/(2pi)), invsqrt2π)
 end
 
 @testset "log" begin
-    @test isapprox(log(1 / 2), loghalf)
+    @test isapprox(log(1/2), loghalf)
     @test isapprox(log(2), logtwo)
     @test isapprox(log(10), logten)
     @test isapprox(log(pi), logπ)
@@ -49,7 +49,7 @@ end
 
 @testset "hash" begin
     for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
-        @test isequal(i == j, hash(i) == hash(j))
+        @test isequal(i==j, hash(i)==hash(j))
     end
 end
 
@@ -72,12 +72,12 @@ end
 
 @testset "IrrationalConstants compared with IrrationalConstants" begin
     for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
-        @test isequal(i == j, Float64(i) == Float64(j))
-        @test isequal(i != j, Float64(i) != Float64(j))
-        @test isequal(i <= j, Float64(i) <= Float64(j))
-        @test isequal(i >= j, Float64(i) >= Float64(j))
-        @test isequal(i < j, Float64(i) < Float64(j))
-        @test isequal(i > j, Float64(i) > Float64(j))
+        @test isequal(i==j, Float64(i)==Float64(j))
+        @test isequal(i!=j, Float64(i)!=Float64(j))
+        @test isequal(i<=j, Float64(i)<=Float64(j))
+        @test isequal(i>=j, Float64(i)>=Float64(j))
+        @test isequal(i<j, Float64(i)<Float64(j))
+        @test isequal(i>j, Float64(i)>Float64(j))
     end
 end
 
@@ -105,9 +105,9 @@ end
     @test !(prevfloat(big(twoπ)) > twoπ)
     @test !(nextfloat(big(twoπ)) < twoπ)
 
-    @test 5293386250278608690 // 842468587426513207 < twoπ
-    @test !(5293386250278608690 // 842468587426513207 > twoπ)
-    @test 5293386250278608690 // 842468587426513207 != twoπ
+    @test 5293386250278608690//842468587426513207 < twoπ
+    @test !(5293386250278608690//842468587426513207 > twoπ)
+    @test 5293386250278608690//842468587426513207 != twoπ
 end
 IrrationalConstants.@irrational i46051 4863.185427757 1548big(pi)
 @testset "IrrationalConstant printing" begin
@@ -119,16 +119,16 @@ IrrationalConstants.@irrational i46051 4863.185427757 1548big(pi)
 end
 
 @testset "IrrationalConstant/Bool multiplication" begin
-    @test false * twoπ === 0.0
-    @test twoπ * false === 0.0
-    @test true * twoπ === Float64(twoπ)
-    @test twoπ * true === Float64(twoπ)
+    @test false*twoπ === 0.0
+    @test twoπ*false === 0.0
+    @test true*twoπ === Float64(twoπ)
+    @test twoπ*true === Float64(twoπ)
 end
 
 # JuliaLang/Julia issue #26324
 @testset "irrational promotion" begin
-    @test twoπ * ComplexF32(2) isa ComplexF32
-    @test twoπ / ComplexF32(2) isa ComplexF32
+    @test twoπ*ComplexF32(2) isa ComplexF32
+    @test twoπ/ComplexF32(2) isa ComplexF32
     @test log(twoπ, ComplexF32(2)) isa ComplexF32
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,21 +3,21 @@ using Documenter
 using Test
 
 @testset "k*pi" begin
-    @test isapprox(2*pi, twoπ)
-    @test isapprox(4*pi, fourπ)
-    @test isapprox(pi/2, halfπ)
-    @test isapprox(pi/4, quartπ)
+    @test isapprox(2 * pi, twoπ)
+    @test isapprox(4 * pi, fourπ)
+    @test isapprox(pi / 2, halfπ)
+    @test isapprox(pi / 4, quartπ)
 end
 
 @testset "k/pi" begin
-    @test isapprox(1/pi, invπ)
-    @test isapprox(2/pi, twoinvπ)
-    @test isapprox(4/pi, fourinvπ)
+    @test isapprox(1 / pi, invπ)
+    @test isapprox(2 / pi, twoinvπ)
+    @test isapprox(4 / pi, fourinvπ)
 end
 
-@testset "1/(k*pi)" begin  
-    @test isapprox(1/(2pi), inv2π)
-    @test isapprox(1/(4pi), inv4π)
+@testset "1/(k*pi)" begin
+    @test isapprox(1 / (2pi), inv2π)
+    @test isapprox(1 / (4pi), inv4π)
 end
 
 @testset "sqrt" begin
@@ -26,14 +26,14 @@ end
     @test isapprox(sqrt(pi), sqrtπ)
     @test isapprox(sqrt(2pi), sqrt2π)
     @test isapprox(sqrt(4pi), sqrt4π)
-    @test isapprox(sqrt(pi/2), sqrthalfπ)
-    @test isapprox(sqrt(1/2), invsqrt2)
-    @test isapprox(sqrt(1/(pi)), invsqrtπ)
-    @test isapprox(sqrt(1/(2pi)), invsqrt2π)
+    @test isapprox(sqrt(pi / 2), sqrthalfπ)
+    @test isapprox(sqrt(1 / 2), invsqrt2)
+    @test isapprox(sqrt(1 / (pi)), invsqrtπ)
+    @test isapprox(sqrt(1 / (2pi)), invsqrt2π)
 end
 
 @testset "log" begin
-    @test isapprox(log(1/2), loghalf)
+    @test isapprox(log(1 / 2), loghalf)
     @test isapprox(log(2), logtwo)
     @test isapprox(log(10), logten)
     @test isapprox(log(pi), logπ)
@@ -49,7 +49,7 @@ end
 
 @testset "hash" begin
     for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
-        @test isequal(i==j, hash(i)==hash(j))
+        @test isequal(i == j, hash(i) == hash(j))
     end
 end
 
@@ -72,12 +72,12 @@ end
 
 @testset "IrrationalConstants compared with IrrationalConstants" begin
     for i in (twoπ, invπ, sqrt2, logtwo), j in (twoπ, invπ, sqrt2, logtwo)
-        @test isequal(i==j, Float64(i)==Float64(j))
-        @test isequal(i!=j, Float64(i)!=Float64(j))
-        @test isequal(i<=j, Float64(i)<=Float64(j))
-        @test isequal(i>=j, Float64(i)>=Float64(j))
-        @test isequal(i<j, Float64(i)<Float64(j))
-        @test isequal(i>j, Float64(i)>Float64(j))
+        @test isequal(i == j, Float64(i) == Float64(j))
+        @test isequal(i != j, Float64(i) != Float64(j))
+        @test isequal(i <= j, Float64(i) <= Float64(j))
+        @test isequal(i >= j, Float64(i) >= Float64(j))
+        @test isequal(i < j, Float64(i) < Float64(j))
+        @test isequal(i > j, Float64(i) > Float64(j))
     end
 end
 
@@ -105,9 +105,9 @@ end
     @test !(prevfloat(big(twoπ)) > twoπ)
     @test !(nextfloat(big(twoπ)) < twoπ)
 
-    @test 5293386250278608690//842468587426513207 < twoπ
-    @test !(5293386250278608690//842468587426513207 > twoπ)
-    @test 5293386250278608690//842468587426513207 != twoπ
+    @test 5293386250278608690 // 842468587426513207 < twoπ
+    @test !(5293386250278608690 // 842468587426513207 > twoπ)
+    @test 5293386250278608690 // 842468587426513207 != twoπ
 end
 IrrationalConstants.@irrational i46051 4863.185427757 1548big(pi)
 @testset "IrrationalConstant printing" begin
@@ -119,21 +119,28 @@ IrrationalConstants.@irrational i46051 4863.185427757 1548big(pi)
 end
 
 @testset "IrrationalConstant/Bool multiplication" begin
-    @test false*twoπ === 0.0
-    @test twoπ*false === 0.0
-    @test true*twoπ === Float64(twoπ)
-    @test twoπ*true === Float64(twoπ)
+    @test false * twoπ === 0.0
+    @test twoπ * false === 0.0
+    @test true * twoπ === Float64(twoπ)
+    @test twoπ * true === Float64(twoπ)
 end
 
 # JuliaLang/Julia issue #26324
 @testset "irrational promotion" begin
-    @test twoπ*ComplexF32(2) isa ComplexF32
-    @test twoπ/ComplexF32(2) isa ComplexF32
+    @test twoπ * ComplexF32(2) isa ComplexF32
+    @test twoπ / ComplexF32(2) isa ComplexF32
     @test log(twoπ, ComplexF32(2)) isa ComplexF32
 end
 
 # issue #23
 @testset "rounding irrationals" begin
+    # without rounding mode
+    @test @inferred(round(twoπ)) == 6.0
+    @test @inferred(round(sqrt2)) == 1.0
+    @test @inferred(round(sqrt3)) == 2.0
+    @test @inferred(round(loghalf)) == -1.0
+
+    # with rounding modes
     for mode in (RoundDown, RoundToZero, RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
         @test @inferred(round(twoπ, mode)) == 6.0
         @test @inferred(round(sqrt2, mode)) == 1.0


### PR DESCRIPTION
This PR fixes https://github.com/JuliaMath/IrrationalConstants.jl/issues/23.

**Before this PR**
```julia
julia> using IrrationalConstants 
[ Info: Precompiling IrrationalConstants [92d709cd-6900-40b7-9082-c6be49f344b6]

julia> round(twoπ)
ERROR: MethodError: no method matching round(::IrrationalConstants.Twoπ, ::RoundingMode{:Nearest})
Closest candidates are:
  round(::Real, ::RoundingMode; digits, sigdigits, base) at floatfuncs.jl:128
  round(::Union{Float16, Float32, Float64}, ::RoundingMode{:Nearest}) at float.jl:370
  round(::Integer, ::RoundingMode) at floatfuncs.jl:157
  ...
```

**After this PR**
```julia
julia> using IrrationalConstants

julia> round(twoπ)
6.0
```

I have not added tests yet because not to make conflicts with https://github.com/JuliaMath/IrrationalConstants.jl/pull/22.