### PR TITLE
fix test suite: de-doctest code block

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -49,7 +49,7 @@ returns `false`.
 
 # Examples
 
-```jldoctest
+```julia-repl
 julia> IrrationalConstants.@irrational(twoπ, 6.2831853071795864769, 2*big(π))
 
 julia> twoπ


### PR DESCRIPTION
The code block was failing the test suite as a doc test. This was happening, specifically, because of the method overwrite warnings.

None of that code block is appropriate for being a doctest, e.g., it tests the exact form of the human-readable `show` output. So the fix is easy.