### PR TITLE
Add effect annotations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.2.3"
+version = "0.2.4"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IrrationalConstants"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 authors = ["JuliaMath"]
-version = "0.2.2"
+version = "0.2.3"
 
 [compat]
 julia = "1"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -115,5 +115,32 @@ macro irrational(sym, val, def, T=Symbol(uppercasefirst(string(sym))))
         @assert isa(big($esym), BigFloat)
         @assert Float64($esym) == Float64(big($esym))
         @assert Float32($esym) == Float32(big($esym))
+
+        # https://github.com/JuliaLang/julia/pull/55886 removed these effects for generic `AbstractIrrational` subtypes
+        @static if isdefined(Base, :_throw_argument_error_irrational_to_rational_bigint)
+            function Base.Rational{$BigInt}(::$eT)
+                Base._throw_argument_error_irrational_to_rational_bigint()
+            end
+        end
+        @static if isdefined(Base, :_irrational_to_rational)
+            Base.@assume_effects :foldable function Base.Rational{T}(x::$eT) where {T<:Integer}
+                Base._irrational_to_rational(T, x)
+            end
+        end
+        @static if isdefined(Base, :_irrational_to_float)
+            Base.@assume_effects :foldable function (::Type{T})(x::$eT, r::RoundingMode) where {T<:Union{Float32,Float64}}
+                Base._irrational_to_float(T, x, r)
+            end
+        end
+        @static if isdefined(Base, :_rationalize_irrational)
+            Base.@assume_effects :foldable function Base.rationalize(::Type{T}, x::$eT; tol::Real=0) where {T<:Integer}
+                Base._rationalize_irrational(T, x, tol)
+            end
+        end
+        @static if isdefined(Base, :_lessrational)
+            Base.@assume_effects :foldable function Base.lessrational(rx::Rational, x::$eT)
+                Base._lessrational(rx, x)
+            end
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,3 +181,8 @@ end
     @test sec(quartπ) === Float64(sec(big(quartπ)))
     @test cot(quartπ) === Float64(cot(big(quartπ)))
 end
+
+# issues #37 and #40
+@testset "slow comparisons" begin
+    @test iszero(@allocated(3.0 <= invsqrt2))
+end


### PR DESCRIPTION
Fixes #37.
Fixes #40.

With this PR I get:

```julia
julia> using IrrationalConstants, BenchmarkTools

julia> @btime 3.0 ≤ pi
  1.041 ns (0 allocations: 0 bytes)
true

julia> @btime 3.0 ≤ invsqrt2
  1.083 ns (0 allocations: 0 bytes)
false
```

Note: To keep up with recent changes in Base, additionally #36 is needed which fixes CI.